### PR TITLE
fix unused var warning

### DIFF
--- a/sapi/common/rsi_device_init_apis.c
+++ b/sapi/common/rsi_device_init_apis.c
@@ -264,7 +264,7 @@ int32_t rsi_device_init(uint8_t select_option)
 
 int32_t rsi_device_deinit(void)
 {
-#ifdef RSI_WITH_OS
+#if defined (RSI_WITH_OS) && defined (RSI_WLAN_ENABLE)
   int32_t status = RSI_SUCCESS;
 #endif
   SL_PRINTF(SL_DEVICE_DEINIT_ENTRY, COMMON, LOG_INFO);


### PR DESCRIPTION
fix unused variable warning with doing a build for BT only
Signed-off-by: Rick Talbott <richard.talbott1@t-mobile.com>